### PR TITLE
Enabled pre-filtered query

### DIFF
--- a/flask_datatables/__init__.py
+++ b/flask_datatables/__init__.py
@@ -40,7 +40,7 @@ def get_resource(Resource, Table, Session, basepath="/"):
             resource, path, endpoint = get_resource(Resource, tableObj, Session, basepath="/")
             api.add_resource(resource, path, endpoint=endpoint)
 
-        
+
     """
     class TmpResource(Resource):
         def get(self):
@@ -53,7 +53,7 @@ def get_resource(Resource, Table, Session, basepath="/"):
             #    print col
 
             # pre build the query so we can add filters to it here
-            query = Session.query(Table)
+            query = Table.query
 
             # check if we are filtering the rows some how
             # this uses the restless view code
@@ -342,6 +342,3 @@ class DataTable(object):
             r = ""
 
         return r() if inspect.isroutine(r) else r
-
-
-

--- a/flask_datatables/__init__.py
+++ b/flask_datatables/__init__.py
@@ -53,7 +53,10 @@ def get_resource(Resource, Table, Session, basepath="/"):
             #    print col
 
             # pre build the query so we can add filters to it here
-            query = Table.query
+            try:
+                query = Table.query  # Flask-SQLAlchemy
+            except:
+                query = Session.query(Table)  # vanilla SQLALchemy
 
             # check if we are filtering the rows some how
             # this uses the restless view code


### PR DESCRIPTION
Hello,

Thanks for providing this Flask extension. It makes using Datatables with Flask a breeze.

With the proposed (minor) change, the pre-filtered query recipe becomes possible. Without it, this recipe fails, because `Session.query(Table)` appears to ignore `Table.query_class`.

More information about this recipe is at https://bitbucket.org/zzzeek/sqlalchemy/wiki/UsageRecipes/PreFilteredQuery, with an example at https://blog.miguelgrinberg.com/post/implementing-the-soft-delete-pattern-with-flask-and-sqlalchemy.

I use this recipe in a system where users only have access to specific data (based on groups they belong to). I prefer this recipe over filtering each query individually.

The changed code passes all tests in `tests` with `py.test`.