### PR TITLE
Dropped flask version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,8 @@ setup(
     install_requires=[
         'querystring_parser==1.2.3',
         'sqlalchemy>=1.0.11',
-        'flask==0.10.1',
+        'flask>=0.10.1',
         'flask-restful>=0.3.5',
         'Faker==0.7.12',
     ],
 )
-


### PR DESCRIPTION
Hello Dennis,

Still happily  using `flask_datatables` :)

The strict Flask version requirement conflicted with some of my other packages.
Relieving this requirement fixed my problem and did not seem to have any negative consequences.

Any known reason why this version is pinned to 0.10.1?

Thanks,
René
